### PR TITLE
Add configurable bucket options from arc's Storage Definition

### DIFF
--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -15,29 +15,29 @@ defmodule Arc.Storage.GCS do
       |> Keyword.put(:x_goog_acl, acl)
       |> transform_headers
 
-    do_put(file, path, gcs_options)
+    do_put(definition, file, path, gcs_options)
   end
 
   def url(definition, version, file_and_scope, options) do
     key = gcs_key(definition, version, file_and_scope)
 
     case Keyword.get(options, :signed, false) do
-      true -> build_signed_url(key)
-      false -> build_url(key)
+      true -> build_signed_url(definition, key)
+      false -> build_url(definition, key)
     end
   end
 
-  defp build_signed_url(endpoint) do
+  defp build_signed_url(definition, endpoint) do
     {:ok, client_id} = Goth.Config.get("client_email")
     expiration = System.os_time(:seconds) + 86_400
 
     path =
-      case bucket() do
+      case definition.bucket() do
         nil -> "/#{endpoint}"
         value -> "/#{value}/#{endpoint}"
       end
 
-    base_url = build_url(endpoint)
+    base_url = build_url(definition, endpoint)
     signature_string = url_to_sign("GET", "", "", expiration, "", path)
     url_encoded_signature = base64_sign_url(signature_string)
 
@@ -47,9 +47,7 @@ defmodule Arc.Storage.GCS do
   end
 
   def delete(definition, version, file_and_scope) do
-    url =
-      gcs_key(definition, version, file_and_scope)
-      |> build_url
+    url = build_url(definition, gcs_key(definition, version, file_and_scope))
 
     case HTTPoison.delete!(url, default_headers()) do
       %{status_code: 204} -> :ok
@@ -57,17 +55,17 @@ defmodule Arc.Storage.GCS do
     end
   end
 
-  defp do_put(%{binary: nil} = file, path, gcs_options) do
-    do_put(path, {:file, file.path}, gcs_options, file.file_name)
+  defp do_put(definition, %{binary: nil} = file, path, gcs_options) do
+    do_put(definition, path, {:file, file.path}, gcs_options, file.file_name)
   end
 
-  defp do_put(%{binary: binary} = file, path, gcs_options)
+  defp do_put(definition, %{binary: binary} = file, path, gcs_options)
        when is_binary(binary) do
-    do_put(path, binary, gcs_options, file.file_name)
+    do_put(definition, path, binary, gcs_options, file.file_name)
   end
 
-  defp do_put(path, body, gcs_options, file_name) do
-    url = build_url(path)
+  defp do_put(definition, path, body, gcs_options, file_name) do
+    url = build_url(definition, path)
     headers = gcs_options ++ default_headers()
 
     case HTTPoison.put!(url, body, headers, hackney_opts()) do
@@ -89,14 +87,6 @@ defmodule Arc.Storage.GCS do
   defp get_token do
     {:ok, %{token: token}} = Token.for_scope(@full_control_scope)
     token
-  end
-
-  defp bucket do
-    case Application.fetch_env(:arc, :bucket) do
-      :error -> nil
-      {:ok, {:system, env_var}} when is_binary(env_var) -> System.get_env(env_var)
-      {:ok, name} -> name
-    end
   end
 
   defp endpoint do
@@ -137,8 +127,8 @@ defmodule Arc.Storage.GCS do
     [{"Authorization", "Bearer #{get_token()}"}]
   end
 
-  defp build_url(path) do
-    case bucket() do
+  defp build_url(definition, path) do
+    case definition.bucket() do
       nil -> "https://#{endpoint()}/#{path}"
       value -> "https://#{endpoint()}/#{value}/#{path}"
     end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Arc.Storage.GCS.Mixfile do
 
   defp deps do
     [
-      {:arc, "~> 0.8"},
+      {:arc, git: "https://github.com/stavro/arc.git", ref: "e4b1af"},
       {:excoveralls, "~> 0.6", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:goth, "~> 0.4"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "arc": {:hex, :arc, "0.8.0", "bb7cf8ea50f30f9c2bb357270c074def42a7ec6a3b4605be731cc5faf8fde6fd", [:mix], [{:ex_aws, "~> 1.1", [hex: :ex_aws, repo: "hexpm", optional: true]}, {:httpoison, "~> 0.11", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.1", [hex: :poison, repo: "hexpm", optional: true]}, {:sweet_xml, "~> 0.6", [hex: :sweet_xml, repo: "hexpm", optional: true]}], "hexpm"},
+  "arc": {:git, "https://github.com/stavro/arc.git", "e4b1afd0f63a7869128aabe4019b99edd8174d20", [ref: "e4b1af"]},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -17,5 +17,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [], [], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
Arc has an overridable `bucket` option on the master branch (but no updates since `0.8.0` on hex).

To allow multiple bucket support, `definition` is passed in to the build URL and `bucket/0` from `Arc.Storage.GCS` is replaced with `definition.bucket()`, which provides its own default implementation.

Using arc from its master branch (commit #e4b1af) until a newer release is available.

TODO: Tests not added yet (but it works in our own repos).